### PR TITLE
📝 Fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ For working on Dream Plus, you can simply clone [this repository](https://github
 * Fill in [the required template](PULL_REQUEST_TEMPLATE.md)
 * Do not include issue numbers in the PR title.
 * Include screenshots and animated GIFs in your pull request whenever possible.
-* Follow the styleguides(#styleguides).
+* Follow the [styleguides](#styleguides).
 * Document new code based on the [Documentation Styleguide](#documentation-styleguide).
 * End all files with a newline.
 


### PR DESCRIPTION
## Description
This PR adds a missing pair of brackets to a markdown link in `CONTRIBUTING.md`.

## Related Issue
None

## Motivation and Context
Looking for issues for Hacktoberfest! 🎉

## Testing Procedure
Visual inspection and clicking the now-working link on my fork.

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/7418049/46341507-76fa2600-c662-11e8-8a13-0636bd5f0ebe.png)
