### PR TITLE
Won't load disqus count script if disqus is disabled.

### DIFF
--- a/layouts/partials/init_body.html
+++ b/layouts/partials/init_body.html
@@ -2,8 +2,10 @@
 {{ partial "js.html" . }}
 
 {{/*Load Disqus JS for Posts*/}}
+{{ with $.Site.DisqusShortname }}
 {{ if eq $.Site.Params.contentType "posts" }}
 	<script id="dsq-count-scr" src="//{{ $.Site.DisqusShortname }}.disqus.com/count.js" async></script>
+{{ end }}
 {{ end }}
 
 {{/*Google Analytics*/}}


### PR DESCRIPTION
## Description
What does your pull request fix/improve?

Remove the unnecessary disqus script request.

> GET http://.disqus.com/count.js net::ERR_EMPTY_RESPONSE

## Related Issue
If this pull request is related to an issue, state it.

## Motivation and Context
What inspired you to to make these improvements? How will your changes improve the project?

## Testing Procedure
The commits should be well tested before creating a pull request. How did you test this pull request?

## Screenshots(if applicable)
Post the screenshots of your improvements in action.
