### PR TITLE
add additional params background.bgColor to customize background

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ These variables have to be in the `[social]` table of `config.toml` or its equiv
 Once this is done, write up the "**About Me**" section of your website in Markdown as directed here:[Error and About Pages](https://github.com/UtkarshVerma/hugo-dream-plus#error-and-about-pages).
 
 ### Toggling the views
-As stated earlier, this theme has two views, **Cards view** and **Posts view**. The type of view rendering depends on the type of content you feed to **Dream Plus**.  
+As stated earlier, this theme has two views, **Cards view** and **Posts view**. The type of view rendering depends on the type of content you feed to **Dream Plus**.
 Therefore:
 * Having `cards` folder in `/content` folder activates *Card view*.
 * Having `posts` folder in `/content` folder activates *Post view*.
@@ -124,7 +124,24 @@ hugo new posts/example.md		#Post creation
 After this, just open your MarkDown card/post and provide the parameters for the card/post.
 
 ### Image background
-To enable setting images as background, you'll have to disable **random colour background** first by setting `colorBG` in `background` table to `false`.
+
+There are 3 different ways to configure background of the theme. These settings are mutual exclusive to each other
+
+#### Randomize background color from a predefined list
+
+```
+randomizeBgColor = true
+```
+
+#### Provide your own css color
+
+```
+bgColor = "#13547A"
+```
+
+#### Randomize background images
+
+To enable setting images as background, you'll have to disable **random colour background** first by setting `randomizeBgColor` in `background` table to `false`.
 Also, enabling image background feature requires the modification of `bgList` array. If you prefer a single image background, then simply give a single value to the array. For example:
 ```
 bgList = ["/images/bg1.jpeg"]
@@ -148,7 +165,7 @@ The covers for each post-card or card are processed by Dream Plus using [Hugo Im
 - Cards: In the bundle. For example, `/content/cards/<card>/cover.<any-extension>`
 - Posts: In the images folder inside the bundle. For example, `/content/posts/<post>/images/cover.<any-extension>`
 
-> ~~**Specifying the cover image through the frontmatter has now been deprecated**~~.  
+> ~~**Specifying the cover image through the frontmatter has now been deprecated**~~.
 Card covers can now be defined through the frontmatter through `cover` key. However image processing won't be applicable on such covers. Also, **frontmatter covers are prioritized over image resources**, therefore, to make the image resource covers render, you'll have to remove the cover key from the frontmatter first.
 
 You may also modify the image processing process through `coverArgs` variable in `[params.features]`. The arguments passed must be for the `.Resize` function since that's what Dream Plus utilizes. For example,
@@ -161,8 +178,8 @@ You may also modify the image processing process through `coverArgs` variable in
 You may configure your website based on the client device by using the `isMobile` JS variable. It is `true` when the client device is a mobile and vice versa.
 
 ### Error and About pages
-This theme supports total customization of **about** and **error** pages. These pages may be customized through the [`about.md`](/exampleSite/content/about.md) and [`404.md`](/exampleSite/content/404.md) files. *Dream Plus reads the above stated files as plain Markdown text* and then renders them. Once you've finished writing the files and modifying them according to your needs, paste them in the `content` folder of your Hugo site.  
-If you don't want these pages to be built by Hugo and served with their own links such as `<website>.<domain>/about` or `<website>.<domain>/404`. Then you can tell Hugo to ignore these through [`ignoreFiles`](https://gohugo.io/getting-started/configuration/#ignore-files-when-rendering) variable in your `config.toml` file as follows:  
+This theme supports total customization of **about** and **error** pages. These pages may be customized through the [`about.md`](/exampleSite/content/about.md) and [`404.md`](/exampleSite/content/404.md) files. *Dream Plus reads the above stated files as plain Markdown text* and then renders them. Once you've finished writing the files and modifying them according to your needs, paste them in the `content` folder of your Hugo site.
+If you don't want these pages to be built by Hugo and served with their own links such as `<website>.<domain>/about` or `<website>.<domain>/404`. Then you can tell Hugo to ignore these through [`ignoreFiles`](https://gohugo.io/getting-started/configuration/#ignore-files-when-rendering) variable in your `config.toml` file as follows:
 ```toml
 ignoreFiles = ["content/404.md", "content/about.md"]
 ```
@@ -194,7 +211,7 @@ Also, the tags, when enabled, won't all be displayed on the header and sidebar b
 [params.tag]
 	enabled = true
 	tagLimit = 10		#Top 10 tags will be displayed
-	#or 
+	#or
 	tagLimit = 0		#Display all tags
 ```
 

--- a/exampleSite/cards.toml
+++ b/exampleSite/cards.toml
@@ -17,7 +17,7 @@ enableEmoji=true
 
 	#Set whether you're hosting "cards" or "post"
 	contentType = "cards"
-	
+
 	siteStartYear = 2018
 
 	[params.author]
@@ -37,7 +37,7 @@ enableEmoji=true
 		customCSS = ["https://cdn.rawgit.com/UtkarshVerma/hugo-dream-plus/ae11561d/exampleSite/static/css/highlight.css"]
 
 	[params.background]
-		colorBG = true
+		randomizeBgColor = true
 
 [social]
 	email = "utkarshverma@pm.me"

--- a/exampleSite/posts.toml
+++ b/exampleSite/posts.toml
@@ -23,7 +23,7 @@ enableEmoji=true
 
 	#Set whether you're hosting "cards" or "post"
 	contentType = "posts"
-	
+
 	siteStartYear = 2018
 
 	[params.author]
@@ -43,7 +43,7 @@ enableEmoji=true
 		customCSS = ["https://cdn.rawgit.com/UtkarshVerma/hugo-dream-plus/ae11561d/exampleSite/static/css/highlight.css"]
 
 	[params.background]
-		colorBG = true
+		randomizeBgColor = true
 
 	#Tags settings
 	[params.tags]

--- a/layouts/partials/background.html
+++ b/layouts/partials/background.html
@@ -2,11 +2,12 @@
 var prevBgIndex = 0;
 var bodyBgSwitchIndex = 0;
 
-{{ $colorBG := $.Site.Params.background.colorBG }}
+{{ $bgColor := $.Site.Params.background.bgColor }}
+{{ $randomizeBgColor := $.Site.Params.background.randomizeBgColor }}
 {{ $bgList := $.Site.Params.background.bgList }}
 {{ $bgBlur := $.Site.Params.background.bgBlur }}
 
-{{ with $colorBG }}
+{{ if $randomizeBgColor }}
 	var gradients = [
 	  [],
 	  ['#40e0d0', '#ff8c00', '#ff0080'], // Wedding Day Blues
@@ -18,7 +19,12 @@ var bodyBgSwitchIndex = 0;
 	  ['#c94b4b', '#4b134f'], // Bighead
 	  ['#23074d', '#cc5333'] // Taran Tado
 	];
-	document.body.style.setProperty('--colorBG', connect(gradients[getRandomInt(0, gradients.length)]));
+
+	var randomBgColor = gradients[getRandomInt(0, gradients.length)].join(", ");
+	var backgroundProperty = 'linear-gradient(to right, ' + randomBgColor + ')';
+	document.body.style.setProperty('--background', backgroundProperty);
+{{ else if $bgColor }}
+	document.body.style.setProperty('--background', {{ $bgColor }});
 {{ else }}
 	{{ if gt (len $bgList) 1 }}
 		var images = {{ $bgList }};
@@ -46,21 +52,9 @@ var bodyBgSwitchIndex = 0;
 	  }
 	  return random;
 	}
-
-	function connect(arr) {
-	  var str = '';
-	  for (var i = 0; i < arr.length; i++) {
-	    if (i !== arr.length - 1) {
-	      str += arr[i] + ', ';
-	    } else {
-	      str += arr[i];
-	    }
-	  }
-	  return str;
-	}
 </script>
 
 {{/*Create blur effect*/}}
-{{ if not $colorBG }}
+{{ if $bgBlur }}
 	<div class="blur-overlay"></div>
 {{ end }}

--- a/layouts/partials/criticalCSS.html
+++ b/layouts/partials/criticalCSS.html
@@ -1,9 +1,9 @@
 <style>
 	body {
 		display: block;
-		--colorBG: "#40e0d0, #ff8c00, #ff0080";
-		{{ with $.Site.Params.background.colorBG }}
-			background: linear-gradient(to right, var(--colorBG)) !important;
+		--background: "linear-gradient(to right, #40e0d0, #ff8c00, #ff0080) !important;";
+		{{ if or ($.Site.Params.background.bgColor) ($.Site.Params.background.randomizeBgColor) }}
+			background: var(--background) !important;
 		{{ else }}
 			background-image: var(--bgImage) !important;
 		{{ end }}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -17,8 +17,8 @@
 <style>
 	body.pushable {
 		display: block;
-		{{ with $.Site.Params.background.colorBG }}
-			background: linear-gradient(to right, var(--colorBG)) !important;
+		{{ if or ($.Site.Params.background.bgColor) ($.Site.Params.background.randomizeBgColor) }}
+			background: var(--background) !important;
 		{{ else }}
 			background-image: var(--bgImage) !important;
 		{{ end }} ;

--- a/layouts/partials/init_head.html
+++ b/layouts/partials/init_head.html
@@ -8,14 +8,13 @@
 <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>
 
 {{/*Load fonts*/}}
- <link href="https://fonts.googleapis.com/css?family=Abril+Fatface|Inconsolata" rel="stylesheet"> 
+ <link href="https://fonts.googleapis.com/css?family=Abril+Fatface|Inconsolata" rel="stylesheet">
 
 {{/*Load rest of the CSS files*/}}
 {{ partial "css.html" . }}
 
 {{/*JS variable initializations*/}}
 <script>
-	var colorBG = {{ $.Site.Params.background.colorBG }}
 	{{ with $.Site.Params.shortest.enabled }}
 		var shToken = {{ $.Site.Params.shortest.apiToken }}
 		var shDomains = {{ $.Site.Params.shortest.domains }}


### PR DESCRIPTION
# Motivation and Context

At the moment, the theme only allows to customize the background in 2 ways:

- set `colorBG` to true to randomize background colors from a predefined list
- set `bgList` to a list of images to randomize background images

For my site, neither of these options are what I want. I just want a simple color for the background color and not changing every time. So I updated the code to allow 3rd way of configuring the background color: by passing the color directly

# Description

I added another parameter `background.bgColor` to allow user specify the background color directly
I also renamed the existing variable `colorBG` to `randomizeBgColor` to make the behavior clear. This is a breaking change but should be simple enough to update
Both `bgColor` and `randomizeBgColor` set the same style property --background which will be used directly in css background
Behavior of `bgList` is still the same

Please help to review my PR