### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -16,7 +16,7 @@
 		{{ $var := replace $val " " "" | lower }}
 		{{ with ($.Scratch.Get $var) }}
 			<div class="item">
-				<a href="{{ index $links $index }}{{ $.Scratch.Get $var }}" {{ if ne $var "mail" }}target="	_blank"{{ end }}>
+				<a href="{{ index $links $index }}{{ $.Scratch.Get $var }}" rel="me" {{ if ne $var "mail" }}target="	_blank"{{ end }}>
 					<i id="ico" class="inverted big link {{ index $icons $index }} icon" title="{{ $val }}"></i>
 				</a>
 			</div>


### PR DESCRIPTION
## Description
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.

## Related Issue
None.

## Motivation and Context
I've been adding rel-me links to a variety of Hugo themes in order to try and popularise use of this pattern across independently produced websites.

## Testing Procedure
Testing not required.