### PR TITLE
Fixes deprecation warnings in hugo 0.55

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
 {{ end }}
 
 {{/*Site generator*/}}
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 
 {{/*Favicon*/}}
 <link rel="shortcut icon" href="{{ if $.Site.Params.favicon }}{{ $.Site.Params.favicon }}{{- else }}/img/defaultFav.ico{{ end }}">

--- a/layouts/posts/rss.xml
+++ b/layouts/posts/rss.xml
@@ -3,7 +3,7 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    {{ .Hugo.Generator }}{{ with .Site.LanguageCode }}
+    {{ hugo.Generator }}{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{ end }}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}


### PR DESCRIPTION
In Hugo 0.55 and later, `.Hugo.Generator` has been deprecated, and should instead be invoked as `hugo.Generator`.  This leads to a couple of noisy deprecation warnings every time Hugo v0.55 or later regenerates a site based upon this theme.

This commit makes the necessary changes to make Hugo v0.55+ happy again.