### PR TITLE
Data.Pages replaced with Site.RegularPages,UniqueID deprecated use .F…

### DIFF
--- a/exampleSite/content/posts/creating-a-new-theme.md
+++ b/exampleSite/content/posts/creating-a-new-theme.md
@@ -675,7 +675,7 @@ $ vi themes/zafta/layouts/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  {{ range first 10 .Data.Pages }}
+  {{ range first 10 .Site.RegularPages }}
     <h1>{{ .Title }}</h1>
   {{ end }}
 </body>
@@ -838,7 +838,7 @@ $ vi themes/zafta/layouts/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  {{ range first 10 .Data.Pages }}
+  {{ range first 10 .Site.RegularPages }}
     <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
   {{ end }}
 </body>
@@ -956,14 +956,14 @@ $ vi themes/zafta/layouts/index.html
 <html>
 <body>
   <h1>posts</h1>
-  {{ range first 10 .Data.Pages }}
+  {{ range first 10 .Site.RegularPages }}
     {{ if eq .Type "post"}}
       <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
     {{ end }}
   {{ end }}
 
   <h1>pages</h1>
-  {{ range .Data.Pages }}
+  {{ range .Site.RegularPages }}
     {{ if eq .Type "page" }}
       <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
     {{ end }}
@@ -1043,14 +1043,14 @@ $ vi themes/zafta/layouts/index.html
 {{ partial "header.html" . }}
 
   <h1>posts</h1>
-  {{ range first 10 .Data.Pages }}
+  {{ range first 10 .Site.RegularPages }}
     {{ if eq .Type "post"}}
       <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
     {{ end }}
   {{ end }}
 
   <h1>pages</h1>
-  {{ range .Data.Pages }}
+  {{ range .Site.RegularPages }}
     {{ if or (eq .Type "page") (eq .Type "about") }}
       <h2><a href="{{ .Permalink }}">{{ .Type }} - {{ .Title }} - {{ .RelPermalink }}</a></h2>
     {{ end }}

--- a/layouts/cards/section.html
+++ b/layouts/cards/section.html
@@ -18,7 +18,7 @@
 			<div class="ui inverted segment">
 				<h2 class="ui header">{{ i18n "allCards" }}<hr><div class="ui grey sub header">{{ .Content }}</div></h2>
 				
-				{{ range .Data.Pages.GroupByDate "2006" }}
+				{{ range .Site.RegularPages.GroupByDate "2006" }}
 					<h3 class="ui header">{{ .Key }}</h3>
 					<ul>
 						{{ range .Pages }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -42,7 +42,7 @@
 
 	{{/*Navigation buttons*/}}
 	{{ if or .context.IsHome (eq .context.Kind "taxonomyTerm") }}
-		{{ $paginator := .context.Paginate (where .context.Data.Pages "Section" .contentType) }}
+		{{ $paginator := .context.Paginate (where .context.Site.RegularPages "Section" .contentType) }}
 		<div class="item">
 			{{ if .context.Paginator.HasPrev }}
 				<a href="{{ $paginator.Prev.URL }}">

--- a/layouts/posts/card.html
+++ b/layouts/posts/card.html
@@ -36,7 +36,7 @@
 	<div class="utility-info">
 		<ul class="utility-list">
 			{{ if $.Site.DisqusShortname }}
-				<div><i class="comment icon"></i><span class="disqus-comment-count" data-disqus-identifier="{{ .UniqueID }}"></span></div>
+				<div><i class="comment icon"></i><span class="disqus-comment-count" data-disqus-identifier="{{ .File.UniqueID }}"></span></div>
 			{{ end }}
 			<div><span><i class="calendar icon"></i>{{ .Date.Format "Jan 2, 2006" }}</span></div>
 			<div><span><i class="clock icon"></i>{{ .ReadingTime }} min read</span></div>

--- a/layouts/posts/section.html
+++ b/layouts/posts/section.html
@@ -19,7 +19,7 @@
 					<div class="ui grey sub header">{{ .Content }}</div>
 				</h2>
 
-				{{ range .Data.Pages.GroupByDate "2006" }}
+				{{ range .Site.RegularPages.GroupByDate "2006" }}
 					<h3 class="ui header">{{ .Key }}</h3>
 					<ul>
 						{{ range .Pages }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -23,7 +23,7 @@
 				<div class="sub header">
 					<div><span><i class="calendar outline icon"></i>{{ .Date.Format "Jan 2, 2006" }}</span></div>
 					{{ if $.Site.DisqusShortname }}
-					<div><span class="disqusComment"><i class="comment outline icon"></i><a href="{{ .Permalink }}#disqus_thread" class="disqus-comment-count" data-disqus-identifier="{{ .UniqueID }}"></a></span></div>{{ end }}
+					<div><span class="disqusComment"><i class="comment outline icon"></i><a href="{{ .Permalink }}#disqus_thread" class="disqus-comment-count" data-disqus-identifier="{{ .File.UniqueID }}"></a></span></div>{{ end }}
 					<div><span><i class="clock outline icon"></i>{{ .ReadingTime }} min read</span></div>
 					<div><span><i class="angle double up icon"></i>{{ i18n "lastUpdate" }} {{ dateFormat "Jan 2, 2006" .Lastmod }}</span></div>
 				</div>


### PR DESCRIPTION
…ile.UniqueID

## Description
Empty homepage
UniqueID deprecated

## Related Issue
Data.Pages must be replaced with Site.RegularPages for the homepage to list the posts
UniqueID with .File.UniqueID

## Motivation and Context
Helping you out after seeing https://github.com/gohugoio/hugoThemes/issues/682

## Testing Procedure
tested it with 58.3 although devs said it started with 0.58